### PR TITLE
Add Metadata to Spec

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -18,10 +18,6 @@ const (
 	You will be first asked for entering common specs which all of your certificates share. So, you enter them once.
 	Next, you will be asked for entering more-specific specs for Root, Intermediate, Server, and Client certificates.
 
-	You can enter a list by comma-separating values.
-	If you don't want to use any of the specs, leave it empty.
-	You can later change these specs by editing "spec.toml" file.
-
 	Best-practice configs are provided by default.
 	You can customize these configs by editing "state.yaml" file.
 	`
@@ -60,12 +56,14 @@ func (c *InitCommand) Run(args []string) int {
 
 	_, err = util.MkDirs("", pki.DirRoot, pki.DirInterm, pki.DirServer, pki.DirClient, pki.DirCSR)
 	if err != nil {
+		c.ui.Error("Failed to create directories. Error: " + err.Error())
 		return ErrorMakeDir
 	}
 
 	state := pki.NewState()
 	err = pki.SaveState(state, pki.FileState)
 	if err != nil {
+		c.ui.Error("Failed to save configs. Error: " + err.Error())
 		return ErrorWriteState
 	}
 
@@ -77,6 +75,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	err = pki.SaveSpec(spec, pki.FileSpec)
 	if err != nil {
+		c.ui.Error("Failed to save specs. Error: " + err.Error())
 		return ErrorWriteSpec
 	}
 

--- a/help/reflect.go
+++ b/help/reflect.go
@@ -64,70 +64,70 @@ func getAskFunc(tag string, ui cli.Ui) askFunc {
 }
 
 func toIntSlice(list string) []int {
-	slice := strings.Split(list, ",")
-	intSlice := make([]int, len(slice))
+	vals := strings.Split(list, ",")
+	intVals := make([]int, len(vals))
 
-	for i, str := range slice {
+	for i, str := range vals {
 		n, err := strconv.ParseInt(str, 10, 32)
 		if err == nil {
-			intSlice[i] = int(n)
+			intVals[i] = int(n)
 		}
 	}
 
-	return intSlice
+	return intVals
 }
 
 func toInt64Slice(list string) []int64 {
-	slice := strings.Split(list, ",")
-	int64Slice := make([]int64, len(slice))
+	vals := strings.Split(list, ",")
+	int64Vals := make([]int64, len(vals))
 
-	for i, str := range slice {
+	for i, str := range vals {
 		n, err := strconv.ParseInt(str, 10, 64)
 		if err == nil {
-			int64Slice[i] = n
+			int64Vals[i] = n
 		}
 	}
 
-	return int64Slice
+	return int64Vals
 }
 
 func toFloat32Slice(list string) []float32 {
-	slice := strings.Split(list, ",")
-	float32Slice := make([]float32, len(slice))
+	vals := strings.Split(list, ",")
+	float32Vals := make([]float32, len(vals))
 
-	for i, str := range slice {
+	for i, str := range vals {
 		n, err := strconv.ParseFloat(str, 32)
 		if err == nil {
-			float32Slice[i] = float32(n)
+			float32Vals[i] = float32(n)
 		}
 	}
 
-	return float32Slice
+	return float32Vals
 }
 
 func toFloat64Slice(list string) []float64 {
-	slice := strings.Split(list, ",")
-	float64Slice := make([]float64, len(slice))
+	vals := strings.Split(list, ",")
+	float64Vals := make([]float64, len(vals))
 
-	for i, str := range slice {
+	for i, str := range vals {
 		n, err := strconv.ParseFloat(str, 64)
 		if err == nil {
-			float64Slice[i] = n
+			float64Vals[i] = n
 		}
 	}
 
-	return float64Slice
+	return float64Vals
 }
 
 func toNetIPSlice(list string) []net.IP {
-	slice := strings.Split(list, ",")
-	netIPSlice := make([]net.IP, len(slice))
+	vals := strings.Split(list, ",")
+	netIPVals := make([]net.IP, len(vals))
 
-	for i, str := range slice {
-		netIPSlice[i] = net.ParseIP(str)
+	for i, str := range vals {
+		netIPVals[i] = net.ParseIP(str)
 	}
 
-	return netIPSlice
+	return netIPVals
 }
 
 func askForStructV(v reflect.Value, tagKey string, ignoreOmitted bool, ui cli.Ui) error {
@@ -279,6 +279,7 @@ func askForStructV(v reflect.Value, tagKey string, ignoreOmitted bool, ui cli.Ui
 	return nil
 }
 
+// AskForStruct reads values from stdin for empty fields of a struct
 func AskForStruct(target interface{}, tagKey string, ignoreOmitted bool, ui cli.Ui) error {
 	// Get into top-level struct
 	v := reflect.ValueOf(target).Elem()

--- a/pki/type.go
+++ b/pki/type.go
@@ -3,7 +3,6 @@ package pki
 import (
 	"net"
 	"path"
-	"strings"
 )
 
 const (
@@ -31,16 +30,18 @@ const (
 	defaultClientCertLength = 2048
 	defaultClientCertDays   = 10 + 30
 
-	defaultRootPolicyMatch    = ""
-	defaultRootPolicySupplied = "CommonName"
-
-	defaultIntermPolicyMatch    = ""
-	defaultIntermPolicySupplied = "CommonName"
-
 	titleRoot   = "Root Certificate Authority"
 	titleInterm = "Intermediate Certificate Authority"
 	titleServer = "Server Certificate Authority"
 	titleClient = "Client Certificate Authority"
+)
+
+var (
+	defaultRootPolicyMatch    = []string{}
+	defaultRootPolicySupplied = []string{"CommonName"}
+
+	defaultIntermPolicyMatch    = []string{}
+	defaultIntermPolicySupplied = []string{"CommonName"}
 )
 
 type (
@@ -62,12 +63,13 @@ type (
 
 	// Spec represents the type for specs
 	Spec struct {
-		Root         Claim  `toml:"root"`
-		Interm       Claim  `toml:"intermediate"`
-		Server       Claim  `toml:"server"`
-		Client       Claim  `toml:"client"`
-		RootPolicy   Policy `toml:"root_policy"`
-		IntermPolicy Policy `toml:"intermediate_policy"`
+		Root         Claim    `toml:"root"`
+		Interm       Claim    `toml:"intermediate"`
+		Server       Claim    `toml:"server"`
+		Client       Claim    `toml:"client"`
+		RootPolicy   Policy   `toml:"root_policy"`
+		IntermPolicy Policy   `toml:"intermediate_policy"`
+		Metadata     Metadata `toml:"metadata"`
 	}
 
 	// Claim represents the subtype for an identity claim
@@ -90,6 +92,9 @@ type (
 		Match    []string `toml:"match"`
 		Supplied []string `toml:"supplied"`
 	}
+
+	// Metadata represents the subtyoe for metadata
+	Metadata map[string][]string
 
 	// Cert represents the type for a certificate
 	Cert struct {
@@ -132,13 +137,14 @@ func NewSpec() *Spec {
 		Server: Claim{},
 		Client: Claim{},
 		RootPolicy: Policy{
-			Match:    strings.Split(defaultRootPolicyMatch, ","),
-			Supplied: strings.Split(defaultRootPolicySupplied, ","),
+			Match:    defaultRootPolicyMatch,
+			Supplied: defaultRootPolicySupplied,
 		},
 		IntermPolicy: Policy{
-			Match:    strings.Split(defaultIntermPolicyMatch, ","),
-			Supplied: strings.Split(defaultIntermPolicySupplied, ","),
+			Match:    defaultIntermPolicyMatch,
+			Supplied: defaultIntermPolicySupplied,
 		},
+		Metadata: Metadata{},
 	}
 }
 

--- a/pki/type_test.go
+++ b/pki/type_test.go
@@ -3,7 +3,6 @@ package pki
 import (
 	"net"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,39 +31,40 @@ func TestNewState(t *testing.T) {
 func TestNewSpec(t *testing.T) {
 	spec := NewSpec()
 
-	expectedClaim := Claim{}
-	expectedRootPolicy := Policy{
-		Match:    strings.Split(defaultRootPolicyMatch, ","),
-		Supplied: strings.Split(defaultRootPolicySupplied, ","),
-	}
-	expectedIntermPolicy := Policy{
-		Match:    strings.Split(defaultIntermPolicyMatch, ","),
-		Supplied: strings.Split(defaultIntermPolicySupplied, ","),
+	expectedSpec := &Spec{
+		Root:   Claim{},
+		Interm: Claim{},
+		Server: Claim{},
+		Client: Claim{},
+		RootPolicy: Policy{
+			Match:    defaultRootPolicyMatch,
+			Supplied: defaultRootPolicySupplied,
+		},
+		IntermPolicy: Policy{
+			Match:    defaultIntermPolicyMatch,
+			Supplied: defaultIntermPolicySupplied,
+		},
+		Metadata: Metadata{},
 	}
 
-	assert.Equal(t, expectedClaim, spec.Root)
-	assert.Equal(t, expectedClaim, spec.Interm)
-	assert.Equal(t, expectedClaim, spec.Server)
-	assert.Equal(t, expectedClaim, spec.Client)
-	assert.Equal(t, expectedRootPolicy, spec.RootPolicy)
-	assert.Equal(t, expectedIntermPolicy, spec.IntermPolicy)
+	assert.Equal(t, expectedSpec, spec)
 }
 
 func TestState(t *testing.T) {
 	tests := []struct {
-		state            State
+		state            *State
 		certType         int
 		expectedConfig   Config
 		expectedConfigOK bool
 	}{
 		{
-			*NewState(),
+			NewState(),
 			-1,
 			Config{},
 			false,
 		},
 		{
-			*NewState(),
+			NewState(),
 			CertTypeRoot,
 			Config{
 				Serial: defaultRootCASerial,
@@ -74,7 +74,7 @@ func TestState(t *testing.T) {
 			true,
 		},
 		{
-			*NewState(),
+			NewState(),
 			CertTypeInterm,
 			Config{
 				Serial: defaultIntermCASerial,
@@ -84,7 +84,7 @@ func TestState(t *testing.T) {
 			true,
 		},
 		{
-			*NewState(),
+			NewState(),
 			CertTypeServer,
 			Config{
 				Serial: defaultServerCertSerial,
@@ -94,7 +94,7 @@ func TestState(t *testing.T) {
 			true,
 		},
 		{
-			*NewState(),
+			NewState(),
 			CertTypeClient,
 			Config{
 				Serial: defaultClientCertSerial,
@@ -114,7 +114,7 @@ func TestState(t *testing.T) {
 }
 
 func TestSpec(t *testing.T) {
-	spec := Spec{
+	spec := &Spec{
 		Root: Claim{
 			Country:      []string{"CA"},
 			Province:     []string{"Ontario"},
@@ -153,7 +153,7 @@ func TestSpec(t *testing.T) {
 	}
 
 	tests := []struct {
-		spec             Spec
+		spec             *Spec
 		certType         int
 		expectedClaim    Claim
 		expectedClaimOK  bool

--- a/pki/workspace_test.go
+++ b/pki/workspace_test.go
@@ -43,12 +43,12 @@ var (
 			stateLoadTest{
 				`invalid yaml`,
 				true,
-				&State{},
+				nil,
 			},
 			specLoadTest{
 				`invalid toml`,
 				true,
-				&Spec{},
+				nil,
 			},
 		},
 		{
@@ -78,41 +78,40 @@ var (
 				false,
 				&State{
 					Root: Config{
-						Serial: int64(10),
+						Serial: 10,
 						Length: 4096,
 						Days:   7300,
 					},
 					Interm: Config{
-						Serial: int64(100),
+						Serial: 100,
 						Length: 4096,
 						Days:   3650,
 					},
 				},
 			},
 			specLoadTest{
-				`[root]
-					locality = [ "Ottawa" ]
+				`
+				[root]
+					country = [ "CA" ]
 					organization = [ "Moorara" ]
 				[server]
 					country = [ "US" ]
-					organization = [ "AWS" ]
+					organization = [ "Milad" ]
 					dns_name = [ "example.com" ]
-					email_address = [ "moorara@example.com" ]
+					email_address = [ "milad@example.com" ]
 				`,
 				false,
 				&Spec{
 					Root: Claim{
-						Locality:     []string{"Ottawa"},
+						Country:      []string{"CA"},
 						Organization: []string{"Moorara"},
 					},
-					Interm: Claim{},
 					Server: Claim{
 						Country:      []string{"US"},
-						Organization: []string{"AWS"},
+						Organization: []string{"Milad"},
 						DNSName:      []string{"example.com"},
-						EmailAddress: []string{"moorara@example.com"},
+						EmailAddress: []string{"milad@example.com"},
 					},
-					Client: Claim{},
 				},
 			},
 		},
@@ -139,29 +138,30 @@ var (
 				false,
 				&State{
 					Root: Config{
-						Serial: int64(10),
+						Serial: 10,
 						Length: 4096,
 						Days:   7300,
 					},
 					Interm: Config{
-						Serial: int64(100),
+						Serial: 100,
 						Length: 4096,
 						Days:   3650,
 					},
 					Server: Config{
-						Serial: int64(1000),
+						Serial: 1000,
 						Length: 2048,
 						Days:   375,
 					},
 					Client: Config{
-						Serial: int64(10000),
+						Serial: 10000,
 						Length: 2048,
 						Days:   40,
 					},
 				},
 			},
 			specLoadTest{
-				`[root]
+				`
+				[root]
 					country = [ "CA", "US" ]
 					province = [ "Ontario", "Massachusetts" ]
 					locality = [ "Ottawa", "Boston" ]
@@ -191,6 +191,11 @@ var (
 				[intermediate_policy]
 					match = ["Organization"]
 					supplied = ["CommonName"]
+				[metadata]
+					RootSkip = ["IPAddress", "StreetAddress", "PostalCode"]
+					IntermSkip = ["IPAddress", "StreetAddress", "PostalCode"]
+					ServerSkip = ["StreetAddress", "PostalCode"]
+					ClientSkip = ["StreetAddress", "PostalCode"]
 				`,
 				false,
 				&Spec{
@@ -229,6 +234,12 @@ var (
 					IntermPolicy: Policy{
 						Match:    []string{"Organization"},
 						Supplied: []string{"CommonName"},
+					},
+					Metadata: Metadata{
+						"RootSkip":   []string{"IPAddress", "StreetAddress", "PostalCode"},
+						"IntermSkip": []string{"IPAddress", "StreetAddress", "PostalCode"},
+						"ServerSkip": []string{"StreetAddress", "PostalCode"},
+						"ClientSkip": []string{"StreetAddress", "PostalCode"},
 					},
 				},
 			},
@@ -288,6 +299,49 @@ var (
 		},
 		{
 			stateSaveTest{
+				NewState(),
+				`root:
+					serial: 10
+					length: 4096
+					days: 7300
+				intermediate:
+					serial: 100
+					length: 4096
+					days: 3650
+				server:
+					serial: 1000
+					length: 2048
+					days: 375
+				client:
+					serial: 10000
+					length: 2048
+					days: 40
+				`,
+			},
+			specSaveTest{
+				NewSpec(),
+				`[root]
+
+				[intermediate]
+
+				[server]
+
+				[client]
+
+				[root_policy]
+					match = []
+					supplied = ["CommonName"]
+
+				[intermediate_policy]
+					match = []
+					supplied = ["CommonName"]
+
+				[metadata]
+				`,
+			},
+		},
+		{
+			stateSaveTest{
 				&State{
 					Root: Config{
 						Serial: 10,
@@ -327,12 +381,13 @@ var (
 					Interm: Claim{},
 					Server: Claim{
 						Country:      []string{"US"},
-						Organization: []string{"AWS"}},
+						Organization: []string{"Milad"}},
 					Client: Claim{},
 					RootPolicy: Policy{
 						Match:    []string{"Organization"},
 						Supplied: []string{"CommonName"},
 					},
+					Metadata: Metadata{},
 				},
 				`[root]
 					locality = ["Ottawa"]
@@ -342,7 +397,7 @@ var (
 
 				[server]
 					country = ["US"]
-					organization = ["AWS"]
+					organization = ["Milad"]
 
 				[client]
 
@@ -351,6 +406,8 @@ var (
 					supplied = ["CommonName"]
 
 				[intermediate_policy]
+
+				[metadata]
 				`,
 			},
 		},
@@ -429,6 +486,12 @@ var (
 						Match:    []string{"Organization"},
 						Supplied: []string{"CommonName"},
 					},
+					Metadata: Metadata{
+						"RootSkip":   []string{"IPAddress", "StreetAddress", "PostalCode"},
+						"IntermSkip": []string{"IPAddress", "StreetAddress", "PostalCode"},
+						"ServerSkip": []string{"StreetAddress", "PostalCode"},
+						"ClientSkip": []string{"StreetAddress", "PostalCode"},
+					},
 				},
 				`[root]
 					country = ["CA", "US"]
@@ -460,6 +523,12 @@ var (
 				[intermediate_policy]
 					match = ["Organization"]
 					supplied = ["CommonName"]
+
+				[metadata]
+					ClientSkip = ["StreetAddress", "PostalCode"]
+					IntermSkip = ["IPAddress", "StreetAddress", "PostalCode"]
+					RootSkip = ["IPAddress", "StreetAddress", "PostalCode"]
+					ServerSkip = ["StreetAddress", "PostalCode"]
 				`,
 			},
 		},


### PR DESCRIPTION
This PR adds a new field to `pki.Spec` type. This field is named `Metadata` and is `map` which lets the clients of `pki` package to store their metadata their and load them later.