### PR TITLE
Add skip feature for claim fields

### DIFF
--- a/cli/const.go
+++ b/cli/const.go
@@ -3,6 +3,11 @@ package cli
 const (
 	rootName = "root"
 
+	mdRootSkip   = "rootSkip"
+	mdIntermSkip = "intermSkip"
+	mdServerSkip = "serverSkip"
+	mdClientSkip = "clientSkip"
+
 	// ErrorEnterState is returned when entering state fails
 	ErrorEnterState = 11
 	// ErrorEnterSpec is returned when entering spec fails

--- a/cli/init.go
+++ b/cli/init.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	initSuccess = "\n ✓ Workspace \n"
+	initSuccess = "\n ✓ Workspace Setup \n"
 
 	initSynopsis = `Initializes a new workspace with desired configs and specs.`
 	initHelp     = `

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -77,16 +77,18 @@ func TestInitCommand(t *testing.T) {
 			[root_policy]
 
 			[intermediate_policy]
+
+			[metadata]
 			`,
 		},
 		{
 			"CustomStateSpec",
 			[]string{},
-			"CA\nOntario\nOttawa\nMilad\n\n\n\n\n\n\n" +
-				"\n\n\n\n\n\n" +
-				"SRE\nexample.com\n\n\n\n\n" +
-				"R&D\nexample.org\n\n\n\n\n" +
-				"QE\n\n\n\n\n\n" +
+			"CA\n\n\nMilad\n\n\n\n\n-\n-\n" +
+				"\n\n\n-\n-\n-\n" +
+				"\n\nSRE\n-\n-\n-\n" +
+				"Ontario\nOttawa\nR&D\nexample.org\n127.0.0.1\n\n" +
+				"Ontario\nOttawa\nQE\n\n\n\n" +
 				"Organization\nCommonName,OrganizationalUnit\n" +
 				"Organization\nCommonName\n",
 			`root:
@@ -108,17 +110,12 @@ func TestInitCommand(t *testing.T) {
 			`,
 			`[root]
 				country = ["CA"]
-				province = ["Ontario"]
-				locality = ["Ottawa"]
 				organization = ["Milad"]
 
 			[intermediate]
 				country = ["CA"]
-				province = ["Ontario"]
-				locality = ["Ottawa"]
 				organization = ["Milad"]
 				organizational_unit = ["SRE"]
-				dns_name = ["example.com"]
 
 			[server]
 				country = ["CA"]
@@ -127,6 +124,7 @@ func TestInitCommand(t *testing.T) {
 				organization = ["Milad"]
 				organizational_unit = ["R&D"]
 				dns_name = ["example.org"]
+				ip_address = ["127.0.0.1"]
 
 			[client]
 				country = ["CA"]
@@ -142,6 +140,12 @@ func TestInitCommand(t *testing.T) {
 			[intermediate_policy]
 				match = ["Organization"]
 				supplied = ["CommonName"]
+
+			[metadata]
+				clientSkip = ["Claim.StreetAddress", "Claim.PostalCode"]
+				intermSkip = ["Claim.StreetAddress", "Claim.PostalCode", "Claim.DNSName", "Claim.IPAddress", "Claim.EmailAddress"]
+				rootSkip = ["Claim.StreetAddress", "Claim.PostalCode", "Claim.DNSName", "Claim.IPAddress", "Claim.EmailAddress"]
+				serverSkip = ["Claim.StreetAddress", "Claim.PostalCode"]
 			`,
 		},
 	}

--- a/cli/req.go
+++ b/cli/req.go
@@ -58,6 +58,21 @@ func NewReqCommand(c pki.Cert) *ReqCommand {
 	}
 }
 
+func (c *ReqCommand) getSkipList(spec *pki.Spec) []string {
+	switch c.c.Type {
+	case pki.CertTypeRoot:
+		return spec.Metadata[mdRootSkip]
+	case pki.CertTypeInterm:
+		return spec.Metadata[mdIntermSkip]
+	case pki.CertTypeServer:
+		return spec.Metadata[mdServerSkip]
+	case pki.CertTypeClient:
+		return spec.Metadata[mdClientSkip]
+	default:
+		return nil
+	}
+}
+
 func (c *ReqCommand) output(text string) {
 	text = fmt.Sprintf(text, strings.ToUpper(c.c.Title()))
 	c.ui.Output(text)
@@ -113,12 +128,13 @@ func (c *ReqCommand) Run(args []string) int {
 		return ErrorInvalidCert
 	}
 
-	err = askForConfig(&config, c.c, c.ui)
+	err = askForConfig(&config, c.c, nil, c.ui)
 	if err != nil {
 		return ErrorEnterConfig
 	}
 
-	err = askForClaim(&claim, c.c, c.ui)
+	skipList := c.getSkipList(spec)
+	err = askForClaim(&claim, c.c, &skipList, c.ui)
 	if err != nil {
 		return ErrorEnterClaim
 	}

--- a/cli/req_test.go
+++ b/cli/req_test.go
@@ -55,7 +55,7 @@ func TestReqCommand(t *testing.T) {
 		input string
 	}{
 		{
-			"GenerateRootCA",
+			"GenerateRootCAWithDefaultSpec",
 			pki.NewState(),
 			pki.NewSpec(),
 			pki.Cert{Type: pki.CertTypeRoot},
@@ -64,7 +64,7 @@ func TestReqCommand(t *testing.T) {
 				"RootCA\n\n\n\n\n\n\n\n\n\n\n",
 		},
 		{
-			"GenerateRootCA",
+			"GenerateRootCAWithCustomSpec",
 			pki.NewState(),
 			&pki.Spec{
 				Root: pki.Claim{
@@ -79,7 +79,25 @@ func TestReqCommand(t *testing.T) {
 				"RootCA\n\n\n\n\n\n\n\n\n",
 		},
 		{
-			"GenerateIntermediateCA",
+			"GenerateRootCAWithCustomSpecAndSkip",
+			pki.NewState(),
+			&pki.Spec{
+				Root: pki.Claim{
+					Country:      []string{"CA"},
+					Province:     []string{"Ontario"},
+					Organization: []string{"Milad"},
+				},
+				Metadata: pki.Metadata{
+					mdRootSkip: []string{"Claim.DNSName", "Claim.IPAddress", "Claim.EmailAddress", "Claim.StreetAddress", "Claim.PostalCode"},
+				},
+			},
+			pki.Cert{Type: pki.CertTypeRoot},
+			[]string{},
+			"password\npassword\n" +
+				"RootCA\n\n\n\n",
+		},
+		{
+			"GenerateIntermediateCAWithDefaultSpec",
 			pki.NewState(),
 			pki.NewSpec(),
 			pki.Cert{Type: pki.CertTypeInterm},
@@ -89,7 +107,7 @@ func TestReqCommand(t *testing.T) {
 				"SRE CA\n\n\n\n\n\n\n\n\n\n\n",
 		},
 		{
-			"GenerateIntermediateCA",
+			"GenerateIntermediateCAWithCustomSpec",
 			pki.NewState(),
 			&pki.Spec{
 				Interm: pki.Claim{
@@ -104,7 +122,25 @@ func TestReqCommand(t *testing.T) {
 				"SRE CA\nOttawa\nSRE\n\n\n\n\n\n",
 		},
 		{
-			"GenerateServerCert",
+			"GenerateIntermediateCAWithCustomSpecAndSkip",
+			pki.NewState(),
+			&pki.Spec{
+				Interm: pki.Claim{
+					Country:      []string{"CA"},
+					Province:     []string{"Ontario"},
+					Organization: []string{"Milad"},
+				},
+				Metadata: pki.Metadata{
+					mdIntermSkip: []string{"Claim.DNSName", "Claim.IPAddress", "Claim.EmailAddress", "Claim.StreetAddress", "Claim.PostalCode"},
+				},
+			},
+			pki.Cert{Type: pki.CertTypeInterm},
+			[]string{"-name=sre"},
+			"password\npassword\n" +
+				"SRE CA\nOttawa\nSRE\n",
+		},
+		{
+			"GenerateServerCertWithDefaultSpec",
 			pki.NewState(),
 			pki.NewSpec(),
 			pki.Cert{Type: pki.CertTypeServer},
@@ -113,7 +149,7 @@ func TestReqCommand(t *testing.T) {
 				"webapp.com\n\n\n\n\n\n\n\n\n\n\n",
 		},
 		{
-			"GenerateServerCert",
+			"GenerateServerCertWithCustomSpec",
 			pki.NewState(),
 			&pki.Spec{
 				Server: pki.Claim{
@@ -128,7 +164,25 @@ func TestReqCommand(t *testing.T) {
 			"webapp.com\nR&D\nwebapp.com\n\n\n\n\n",
 		},
 		{
-			"GenerateClientCert",
+			"GenerateServerCertWithCustomSpecAndSkip",
+			pki.NewState(),
+			&pki.Spec{
+				Server: pki.Claim{
+					Country:      []string{"CA"},
+					Province:     []string{"Ontario"},
+					Locality:     []string{"Toronto"},
+					Organization: []string{"Milad"},
+				},
+				Metadata: pki.Metadata{
+					mdServerSkip: []string{"Claim.StreetAddress", "Claim.PostalCode"},
+				},
+			},
+			pki.Cert{Type: pki.CertTypeServer},
+			[]string{"-name=webapp"},
+			"webapp.com\nR&D\nwebapp.com\n127.0.0.1\n\n",
+		},
+		{
+			"GenerateClientCertWithDefaultSpec",
 			pki.NewState(),
 			pki.NewSpec(),
 			pki.Cert{Type: pki.CertTypeClient},
@@ -137,7 +191,7 @@ func TestReqCommand(t *testing.T) {
 				"MyService\n\n\n\n\n\n\n\n\n\n\n",
 		},
 		{
-			"GenerateClientCert",
+			"GenerateClientCertWithCustomSpec",
 			pki.NewState(),
 			&pki.Spec{
 				Client: pki.Claim{
@@ -150,6 +204,24 @@ func TestReqCommand(t *testing.T) {
 			pki.Cert{Type: pki.CertTypeClient},
 			[]string{"-name=myservice"},
 			"MyService\nR&D\n\n\n\n\n\n",
+		},
+		{
+			"GenerateClientCertWithCustomSpecAndSkip",
+			pki.NewState(),
+			&pki.Spec{
+				Client: pki.Claim{
+					Country:      []string{"CA"},
+					Province:     []string{"Ontario"},
+					Locality:     []string{"Montreal"},
+					Organization: []string{"Milad"},
+				},
+				Metadata: pki.Metadata{
+					mdClientSkip: []string{"Claim.StreetAddress", "Claim.PostalCode"},
+				},
+			},
+			pki.Cert{Type: pki.CertTypeClient},
+			[]string{"-name=myservice"},
+			"MyService\nQE\n\n\n\n",
 		},
 	}
 

--- a/cli/sign.go
+++ b/cli/sign.go
@@ -132,7 +132,7 @@ func (c *SignCommand) Run(args []string) (exit int) {
 	}
 
 	c.ui.Output(signEnterConfigCA)
-	err = askForConfig(&configCA, cCA, c.ui)
+	err = askForConfig(&configCA, cCA, nil, c.ui)
 	if err != nil {
 		return ErrorEnterConfig
 	}

--- a/help/reflect_test.go
+++ b/help/reflect_test.go
@@ -33,44 +33,53 @@ type example struct {
 
 func TestAskForStruct(t *testing.T) {
 	tests := []struct {
-		title           string
-		tagKey          string
-		ignoreOmitted   bool
-		example         *example
-		input           string
-		expectError     bool
-		expectedExample *example
+		title            string
+		tagKey           string
+		ignoreOmitted    bool
+		skipList         []string
+		example          *example
+		input            string
+		expectError      bool
+		expectedExample  *example
+		expectedSkipList []string
 	}{
 		{
 			"ErrorNoBoolInput",
 			"custom", false,
+			nil,
 			&example{},
 			``,
 			true,
+			nil,
 			nil,
 		},
 		{
 			"ErrorNoIntInput",
 			"custom", false,
+			nil,
 			&example{},
 			`true
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoInt64Input",
 			"custom", false,
+			nil,
 			&example{},
 			`true
 			27
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoFloat32Input",
 			"custom", false,
+			nil,
 			&example{},
 			`true
 			27
@@ -78,10 +87,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoFloat64Input",
 			"custom", false,
+			nil,
 			&example{},
 			`true
 			27
@@ -90,10 +101,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoStringInput",
 			"custom", false,
+			nil,
 			&example{},
 			`true
 			27
@@ -103,10 +116,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorSecretInvalid",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -118,10 +133,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorSecretNotConfirmed",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -133,10 +150,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorSecretNotMatching",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -149,10 +168,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoIntListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -165,10 +186,12 @@ func TestAskForStruct(t *testing.T) {
 			``,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoInt64ListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -182,10 +205,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoFloat32ListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -200,10 +225,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoFloat64ListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -219,10 +246,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoStringListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -239,10 +268,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoIPListInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -260,10 +291,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"ErrorNoStructInput",
 			"custom", false,
+			nil,
 			&example{
 				Bool:    true,
 				Int:     27,
@@ -282,10 +315,12 @@ func TestAskForStruct(t *testing.T) {
 			`,
 			true,
 			nil,
+			nil,
 		},
 		{
 			"SuccessIgnoreOmitted",
 			"custom", true,
+			[]string{},
 			&example{},
 			`27
 			64
@@ -311,10 +346,12 @@ func TestAskForStruct(t *testing.T) {
 				Float64: 3.1415,
 				Text:    "password",
 			},
+			[]string{},
 		},
 		{
 			"SuccessEnterAll",
 			"custom", false,
+			[]string{},
 			&example{},
 			`true
 			27
@@ -354,6 +391,37 @@ func TestAskForStruct(t *testing.T) {
 					String: "nested",
 				},
 			},
+			[]string{},
+		},
+		{
+			"SuccessSkipSomeFields",
+			"custom", true,
+			[]string{"example.String", "example.Text"},
+			&example{},
+			`27
+			64
+			-
+			-
+			1,2,3,4
+			-
+			-
+			-
+			-
+			-
+			-
+			-
+			`,
+			false,
+			&example{
+				Int:      27,
+				Int64:    64,
+				IntSlice: []int{1, 2, 3, 4},
+			},
+			[]string{
+				"example.String", "example.Text",
+				"example.Float32", "example.Float64",
+				"example.Int64Slice", "example.Float32Slice", "example.Float64Slice", "example.StringSlice", "example.IPSlice",
+				"inner.Int", "inner.String"},
 		},
 	}
 
@@ -361,13 +429,14 @@ func TestAskForStruct(t *testing.T) {
 		t.Run(test.title, func(t *testing.T) {
 			r := strings.NewReader(test.input)
 			mockUI := NewMockUI(r)
-			err := AskForStruct(test.example, test.tagKey, test.ignoreOmitted, mockUI)
+			err := AskForStruct(test.example, test.tagKey, test.ignoreOmitted, &test.skipList, mockUI)
 
 			if test.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, test.expectedExample, test.example)
+				assert.Equal(t, test.expectedSkipList, test.skipList)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a really cool feature! Now, when initiating a new workspace using `init` command, you can enter `-` for a field to permanently skip it in the future. So, you won't be asked for that field anymore.